### PR TITLE
Add fixes and documentation to build RPMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Building requires a few dependencies:
 
 `$ ./configure && make`
 
+### RPM
+
+`$ make rpms`
+
 ## License
 
 Copyright (C) 2015 Facebook, Inc.

--- a/configure.ac
+++ b/configure.ac
@@ -34,8 +34,7 @@ AC_PROG_LN_S
 AC_PROG_EGREP
 
 # Dependencies
-AC_CHECK_HEADER([glusterfs/api/glfs.h],,[AC_MSG_ERROR([cannot find glusterfs api headers])])
-PKG_CHECK_MODULES([GLFS], [glusterfs-api >= 3])
+PKG_CHECK_MODULES([GLFS], [glusterfs-api >= 3],,[AC_MSG_ERROR([cannot find glusterfs api headers])])
 PKG_CHECK_MODULES([TIRPC], [libtirpc >= 0.2.1])
 
 AC_CHECK_PROG([HAVE_HELP2MAN],[help2man],[yes],[no])

--- a/src/glfs-cat.c
+++ b/src/glfs-cat.c
@@ -55,14 +55,14 @@ gluster_get (glfs_t *fs, const char *filename) {
 
         fd = glfs_open (fs, filename, O_RDONLY);
         if (fd == NULL) {
-                error (0, errno, state->url);
+                error (0, errno, "%s", state->url);
                 goto out;
         }
 
         // don't allow concurrent reads and writes.
         ret = gluster_lock (fd, F_WRLCK);
         if (ret == -1) {
-                error (0, errno, state->url);
+                error (0, errno, "%s", state->url);
                 goto out;
         }
 
@@ -239,7 +239,7 @@ cat_without_context ()
 
         ret = gluster_getfs (&fs, state->gluster_url);
         if (ret == -1) {
-                error (0, errno, state->url);
+                error (0, errno, "%s", state->url);
                 goto out;
         }
 

--- a/src/glfs-cp.c
+++ b/src/glfs-cp.c
@@ -523,7 +523,7 @@ local_to_remote (const char *local_path, const char *remote_path, glfs_t *fs)
 
         fd = open (local_path, O_RDONLY);
         if (fd == -1) {
-                error (0, errno, local_path);
+                error (0, errno, "%s", local_path);
                 goto out;
         }
 
@@ -605,13 +605,13 @@ remote_to_local (const char *remote_path, const char *local_path, glfs_t *fs)
 
         remote_fd = glfs_open (fs, remote_path, O_RDONLY);
         if (remote_fd == NULL) {
-                error (0, errno, remote_path);
+                error (0, errno, "%s", remote_path);
                 goto out;
         }
 
         local_fd = open (full_path, O_CREAT | O_WRONLY, get_default_file_mode_perm ());
         if (local_fd == -1) {
-                error (0, errno, full_path);
+                error (0, errno, "%s", full_path);
                 goto out;
         }
 
@@ -670,13 +670,13 @@ remote_to_remote (const char *source_path, const char *dest_path, glfs_t *source
 
         source_fd = glfs_open (source_fs, source_path, O_RDONLY);
         if (source_fd == NULL) {
-                error (0, errno, source_path);
+                error (0, errno, "%s", source_path);
                 goto out;
         }
 
         dest_fd = glfs_creat (dest_fs, full_path, O_CREAT | O_WRONLY, get_default_file_mode_perm ());
         if (dest_fd == NULL) {
-                error (0, errno, full_path);
+                error (0, errno, "%s", full_path);
                 goto out;
         }
 
@@ -729,7 +729,7 @@ cp_without_context ()
                 case LOCAL_TO_REMOTE:
                         ret = gluster_getfs (&dest_fs, state->gluster_dest);
                         if (ret == -1) {
-                                error (0, errno, state->dest);
+                                error (0, errno, "%s", state->dest);
                                 goto out;
                         }
 
@@ -750,7 +750,7 @@ cp_without_context ()
                 case REMOTE_TO_LOCAL:
                         ret = gluster_getfs (&source_fs, state->gluster_source);
                         if (ret == -1) {
-                                error (0, errno, state->source);
+                                error (0, errno, "%s", state->source);
                                 goto out;
                         }
 
@@ -771,7 +771,7 @@ cp_without_context ()
                 case REMOTE_TO_REMOTE:
                         ret = gluster_getfs (&dest_fs, state->gluster_dest);
                         if (ret == -1) {
-                                error (0, errno, state->dest);
+                                error (0, errno, "%s", state->dest);
                                 goto out;
                         }
 
@@ -792,7 +792,7 @@ cp_without_context ()
                         } else {
                                 ret = gluster_getfs (&source_fs, state->gluster_source);
                                 if (ret == -1) {
-                                        error (0, errno, state->source);
+                                        error (0, errno, "%s", state->source);
                                         goto out;
                                 }
 
@@ -848,7 +848,7 @@ cp_with_context (glfs_t *fs)
                 case ESTABLISHED_TO_REMOTE:
                         ret = gluster_getfs (&dest_fs, state->gluster_dest);
                         if (ret == -1) {
-                                error (0, errno, state->dest);
+                                error (0, errno, "%s", state->dest);
                                 goto out;
                         }
 
@@ -868,7 +868,7 @@ cp_with_context (glfs_t *fs)
                 case REMOTE_TO_ESTABLISHED:
                         ret = gluster_getfs (&source_fs, state->gluster_source);
                         if (ret == -1) {
-                                error (0, errno, state->source);
+                                error (0, errno, "%s", state->source);
                                 goto out;
                         }
 

--- a/src/glfs-ls.c
+++ b/src/glfs-ls.c
@@ -314,13 +314,13 @@ ls_dir (glfs_t *fs, char *path, char *pattern, void (*print_func)(const char *, 
 
         ret = glfs_lstat (fs, path, &stat);
         if (ret == -1) {
-                error (0, errno, path);
+                error (0, errno, "%s", path);
                 goto out;
         }
 
         fd = glfs_opendir (fs, path);
         if (fd == NULL) {
-                error (0, errno, path);
+                error (0, errno, "%s", path);
                 goto out;
         }
 

--- a/src/glfs-put.c
+++ b/src/glfs-put.c
@@ -282,7 +282,7 @@ main (int argc, char *argv[])
 
         ret = gluster_getfs (&fs, state->gluster_url);
         if (ret == -1) {
-                error (0, errno, state->url);
+                error (0, errno, "%s", state->url);
                 goto err;
         }
 
@@ -303,7 +303,7 @@ main (int argc, char *argv[])
 
         ret = gluster_put (fs, state);
         if (ret == -1) {
-                error (0, errno, state->url);
+                error (0, errno, "%s", state->url);
                 goto err;
         }
 

--- a/src/glfs-tail.c
+++ b/src/glfs-tail.c
@@ -516,7 +516,7 @@ do_tail_without_context ()
 
         ret = gluster_getfs (&fs, state->gluster_url);
         if (ret == -1) {
-                error (0, errno, state->url);
+                error (0, errno, "%s", state->url);
                 goto out;
         }
 


### PR DESCRIPTION
These changes make it possible to build RPMs on Fedora 22. This uses the
included .spec file that gets generated when the sources are prepared:

```
$ ./autogen.sh
$ ./configure
```

Once these commands have finished, the RPMs can be built with:

```
$ make rpms
```

Signed-off-by: Niels de Vos ndevos@redhat.com
