### PR TITLE
configure: no need to check for libtirpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ to do work.
 Building requires a few dependencies:
 
 1. `glusterfs-api-devel`
-1. `libtirpc-devel`
 1. `help2man`
 1. `autoconf >= 2.69`
 1. `automake >= 1.15`

--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,6 @@ AC_PROG_EGREP
 
 # Dependencies
 PKG_CHECK_MODULES([GLFS], [glusterfs-api >= 3],,[AC_MSG_ERROR([cannot find glusterfs api headers])])
-PKG_CHECK_MODULES([TIRPC], [libtirpc >= 0.2.1])
 
 AC_CHECK_PROG([HAVE_HELP2MAN],[help2man],[yes],[no])
 AM_CONDITIONAL([HAVE_HELP2MAN], [test "x$HAVE_HELP2MAN" = xyes])

--- a/glusterfs-coreutils.spec.in
+++ b/glusterfs-coreutils.spec.in
@@ -6,10 +6,8 @@ Vendor:           Gluster Community
 License:          GPLv3
 Group:            System Environment/Base
 BuildRequires:    glusterfs-api-devel >= 3.6.0
-BuildRequires:    libtirpc-devel >= 0.2.4
 BuildRequires:    help2man >= 1.36
 Requires:         glusterfs-api >= 3.6.0
-Requires:         libtirpc >= 0.2.4
 URL:              http://www.gluster.org/docs/index.php/GlusterFS
 Source0:          @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.gz
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,8 +38,8 @@ __top_builddir__build_bin_gfcli_SOURCES = glfs-cli.c \
 					  glfs-util.c
 
 __top_builddir__build_bin_gfcli_CFLAGS = $(GLFS_CFLAGS)
-__top_builddir__build_bin_gfcli_LDADD = $(LDADD) $(GLFS_LIBS) $(TIRPC_LIBS)
+__top_builddir__build_bin_gfcli_LDADD = $(LDADD) $(GLFS_LIBS)
 
 __top_builddir__build_bin_gfput_SOURCES = glfs-put.c glfs-util.c
 __top_builddir__build_bin_gfput_CFLAGS = $(GLFS_CFLAGS)
-__top_builddir__build_bin_gfput_LDADD = $(LDADD) $(GLFS_LIBS) $(TIRPC_LIBS)
+__top_builddir__build_bin_gfput_LDADD = $(LDADD) $(GLFS_LIBS)


### PR DESCRIPTION
libtirpc is not used by Gluster, there is no build or link dependency.

Signed-off-by: Niels de Vos ndevos@redhat.com
