### PR TITLE
Fixes for exit code path from gluster shell on receving EOF

### DIFF
--- a/src/glfs-cli.c
+++ b/src/glfs-cli.c
@@ -214,6 +214,7 @@ start_shell ()
         }
 
 out:
+        printf ("\n");
         free (line);
         return ret;
 }
@@ -390,8 +391,6 @@ main (int argc, char *argv[])
                 if (ctx->options->debug) {
                         print_xlator_options (&ctx->options->xlator_options);
                 }
-
-                ret = start_shell ();
         }
 
         cleanup ();


### PR DESCRIPTION
Inside gluster remote shell, quitting with Ctrl+D(EOF) forces users to fall-back into the same shell again. This fallback is due to a second call to start the same shell as soon as we return from the first on
receving EOF. Apart from removing the second call, this change also adds a missing newline after exiting the current shell.

Signed-off-by: Anoop C S anoopcs@redhat.com
