### PR TITLE
Add flock core utility support

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,6 +17,7 @@ EXTRA_DIST = glfs-cat.h \
 	     glfs-cp.h \
 	     glfs-cli-commands.h \
 	     glfs-cli.h \
+	     glfs-flock.h \
 	     glfs-ls.h \
 	     glfs-mkdir.h \
 	     glfs-rm.h \
@@ -29,6 +30,7 @@ __top_builddir__build_bin_gfcli_SOURCES = glfs-cli.c \
 					  glfs-cli-commands.c \
 					  glfs-cat.c \
 					  glfs-cp.c \
+					  glfs-flock.c \
 					  glfs-ls.c \
 					  glfs-mkdir.c \
 					  glfs-rm.c \

--- a/src/glfs-cat.c
+++ b/src/glfs-cat.c
@@ -60,7 +60,7 @@ gluster_get (glfs_t *fs, const char *filename) {
         }
 
         // don't allow concurrent reads and writes.
-        ret = gluster_lock (fd, F_WRLCK);
+        ret = gluster_lock (fd, F_WRLCK, false);
         if (ret == -1) {
                 error (0, errno, "%s", state->url);
                 goto out;

--- a/src/glfs-cli-commands.c
+++ b/src/glfs-cli-commands.c
@@ -127,8 +127,27 @@ int
 cli_disconnect (struct cli_context *ctx)
 {
         int ret = 0;
+        struct fd_list *cur, *ptr = NULL;
 
         free_xlator_options (&ctx->options->xlator_options);
+
+        /* Traverse fd_list and cleanup each entry.*/
+        ptr = ctx->flist;
+        while (ptr) {
+                if (ptr->fd) {
+                        glfs_close (ptr->fd);
+                        ptr->fd = NULL;
+                }
+
+                if (ptr->path) {
+                        free (ptr->path);
+                        ptr->path = NULL;
+                }
+
+                cur = ptr;
+                ptr = ptr->next;
+                free (cur);
+        }
 
         if (ctx->fs) {
                 // FIXME: Memory leak occurs here in GFS >= 3.6. Test with 3.7

--- a/src/glfs-cli.h
+++ b/src/glfs-cli.h
@@ -6,8 +6,15 @@
 #include <glusterfs/api/glfs.h>
 #include <stdbool.h>
 
+struct fd_list {
+        struct fd_list *next;
+        glfs_fd_t *fd;
+        char *path;
+};
+
 struct cli_context {
         glfs_t *fs;
+        struct fd_list *flist;
         struct gluster_url *url;
         struct options *options;
         char *conn_str;

--- a/src/glfs-cp.c
+++ b/src/glfs-cp.c
@@ -547,7 +547,7 @@ local_to_remote (const char *local_path, const char *remote_path, glfs_t *fs)
                 goto out;
         }
 
-        ret = gluster_lock (remote_fd, F_WRLCK);
+        ret = gluster_lock (remote_fd, F_WRLCK, false);
         if (ret == -1) {
                 error (0, errno, "failed to lock %s", full_path);
                 goto out;
@@ -615,7 +615,7 @@ remote_to_local (const char *remote_path, const char *local_path, glfs_t *fs)
                 goto out;
         }
 
-        ret = gluster_lock (remote_fd, F_WRLCK);
+        ret = gluster_lock (remote_fd, F_WRLCK, false);
         if (ret == -1) {
                 error (0, errno, "failed to lock %s", remote_path);
                 goto out;

--- a/src/glfs-flock.c
+++ b/src/glfs-flock.c
@@ -1,0 +1,291 @@
+/**
+ * A utility to request for full file advisory lock on a file from remote Gluster volume.
+ *
+ * Copyright (C) 2016 Red Hat Inc.
+ */
+
+#include <config.h>
+
+#include "glfs-flock.h"
+#include "glfs-util.h"
+
+#include <errno.h>
+#include <error.h>
+#include <getopt.h>
+#include <glusterfs/api/glfs.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define AUTHORS "Written by Anoop C S."
+
+/**
+ * Used to store the state of the program, including user supplied options.
+ *
+ * path         : Path used to find the remote file or directory (supplied by user).
+ * block        : Whether to block the lock request in case of a conflicting lock.
+ * debug        : Whether to log additional debug information.
+ * l_type       : Stores the requested lock type.
+ */
+struct state {
+        char *path;
+        bool block;
+        bool debug;
+        short l_type;
+};
+
+static struct state *state;
+
+static struct option const long_options[] =
+{
+        {"exclusive", no_argument, NULL, 'e'},
+        {"help", no_argument, NULL, 'h'},
+        {"nonblock", no_argument, NULL, 'n'},
+        {"shared", no_argument, NULL, 's'},
+        {"unlock", no_argument, NULL, 'u'},
+        {"version", no_argument, NULL, 'v'},
+        {NULL, no_argument, NULL, 0}
+};
+
+static void
+usage ()
+{
+        printf ("Usage: %s [OPTION]... URL\n"
+                "Request a full file advisory lock on files from a remote Gluster volume.\n\n"
+                "  -e, --exclusive              Obtain an exclusive lock. This is the default.\n"
+                "  -h, --help                   Display this help and exit.\n"
+                "  -n, --nonblock               Fail rather than wait if the lock cannot be immediately acquired.\n"
+                "  -s, --shared                 Obtain a shared lock.\n"
+                "  -u, --unlock                 Drop  a  lock.\n"
+                "  -v, --version                Output version information and exit\n\n"
+                "Examples:\n"
+                "  gfcli (localhost/groot)> flock /file\n"
+                "       In the context of a shell with a connection established, request full file\n"
+                "       lock on a file present under root of the Gluster volume groot on localhost.\n",
+                program_invocation_name);
+}
+
+static int
+parse_options (int argc, char *argv[])
+{
+        int ret = -1;
+        int opt = 0;
+        int option_index = 0;
+
+        optind = 0;
+        while (true) {
+                opt = getopt_long (argc, argv, "ehnsuv", long_options,
+                                   &option_index);
+
+                if (opt == -1) {
+                        break;
+                }
+
+                switch (opt) {
+                        case 'e':
+                                state->l_type = F_WRLCK;
+                                break;
+                        case 'n':
+                                state->block = false;
+                                break;
+                        case 's':
+                                state->l_type = F_RDLCK;
+                                break;
+                        case 'u':
+                                state->l_type = F_UNLCK;
+                                break;
+                        case 'v':
+                                printf ("%s (%s) %s\n%s\n%s\n%s\n",
+                                        program_invocation_name,
+                                        PACKAGE_NAME,
+                                        PACKAGE_VERSION,
+                                        COPYRIGHT,
+                                        LICENSE,
+                                        AUTHORS);
+                                ret = -2;
+                                goto out;
+                        case 'h':
+                                usage ();
+                                ret = -2;
+                                goto out;
+                        default:
+                                goto err;
+                }
+        }
+
+        if (argc <= optind) {
+                usage ();
+                ret = -2;
+                goto out;
+        } else {
+                state->path = strdup (argv[argc - 1]);
+                if (state->path == NULL) {
+                        error (0, errno, "strdup");
+                        goto out;
+                }
+                ret = 0;
+        }
+
+        goto out;
+
+err:
+        error (0, 0, "Try --help for more information.");
+out:
+        return ret;
+}
+
+static struct state*
+init_state ()
+{
+        struct state *state = malloc (sizeof (*state));
+
+        if (state == NULL) {
+                goto out;
+        }
+
+        state->debug = false;
+        state->path = NULL;
+        state->block = true;
+        state->l_type = F_WRLCK;
+
+out:
+        return state;
+}
+
+static char *
+format_file_path (char *str)
+{
+        char *last_char;
+
+        while (*str == '/')
+                str++;
+
+        if (*str == '\0')
+                return str;
+
+        last_char = str + strlen (str) - 1;
+
+        while (last_char > str && *last_char == '/')
+                last_char--;
+
+        *(last_char + 1) = '\0';
+
+        return str;
+}
+
+static glfs_fd_t *
+query_fd_from_path (struct cli_context *ctx, const char *path)
+{
+        struct fd_list *ptr = NULL;
+
+        ptr = ctx->flist;
+        while (ptr) {
+                if (strcmp(ptr->path, path) == 0)
+                        return ptr->fd;
+
+                ptr = ptr->next;
+        }
+
+        return NULL;
+}
+
+static int
+flock_with_fs (struct cli_context **ctx)
+{
+        int ret = -1;
+        char *tmp_path = NULL;
+        glfs_fd_t *fd = NULL;
+        struct fd_list *new, *ptr, *cur = NULL;
+
+        if (state->debug)
+                glfs_set_logging ((*ctx)->fs, "/dev/stderr", GF_LOG_DEBUG);
+
+        /* Format the file path in such a way that leading and trailing forward
+         * slashes are removed for a generic comaprison. */
+        tmp_path = strdup (format_file_path (state->path));
+
+        /* Check whether we already have an open fd corresponding to the file
+         * on which lock request is issued.*/
+        fd = query_fd_from_path (*ctx, tmp_path);
+        if (!fd) {
+                /* No previous open fd. Create new one and store it to fd_list
+                 * for future reference.*/
+                new = (struct fd_list *)malloc (sizeof(struct fd_list));
+                new->path = NULL;
+
+                new->fd = fd = glfs_open ((*ctx)->fs, state->path, O_RDWR);
+                if (!fd) {
+                        error (0, errno, "failed to open %s", state->path);
+                        ret = -1;
+                        goto out;
+                }
+
+                new->path = strdup (tmp_path);
+                new->next = NULL;
+
+                if ((*ctx)->flist == NULL) {
+                        (*ctx)->flist = new;
+                } else {
+                        ptr = (*ctx)->flist;
+                        while (ptr) {
+                                cur = ptr;
+                                ptr = ptr->next;
+                        }
+
+                        cur->next = new;
+                }
+        }
+
+        /* Request advisory lock. */
+        ret = gluster_lock (fd, state->l_type, state->block);
+        if (ret)
+                error (0, errno, "failed to lock %s", state->path);
+out:
+        if (tmp_path)
+                free (tmp_path);
+
+        return ret;
+}
+
+int
+do_flock (struct cli_context *ctx)
+{
+        int argc = ctx->argc;
+        char **argv = ctx->argv;
+        int ret = -1;
+
+        state = init_state ();
+        if (state == NULL) {
+                error (0, errno, "failed to initialize state");
+                ret = -1;
+                goto out;
+        }
+
+        state->debug = ctx->options->debug;
+
+        if (ctx->fs) {
+                ret = parse_options (argc, argv);
+                if (ret != 0) {
+                        goto out;
+                }
+
+                ret = flock_with_fs (&ctx);
+        } else {
+                /* flock can only be invoked within a Gluster remote shell
+                 * connected to Gluster volume. Or else we return error. */
+                printf ("Client not connected to remote Gluster volume. Use "
+                        "connect command to do so and try flock again.\n");
+        }
+
+out:
+        if (state) {
+                if (state->path) {
+                        free (state->path);
+                }
+                free (state);
+        }
+
+        return ret;
+}

--- a/src/glfs-flock.h
+++ b/src/glfs-flock.h
@@ -1,0 +1,9 @@
+#ifndef GLFS_FLOCK_H
+#define GLFS_FLOCK_H
+
+#include "glfs-cli.h"
+
+int
+do_flock (struct cli_context *ctx);
+
+#endif

--- a/src/glfs-put.c
+++ b/src/glfs-put.c
@@ -230,7 +230,7 @@ gluster_put (glfs_t *fs, struct state *state)
                 goto out;
         }
 
-        ret = gluster_lock (fd, F_WRLCK);
+        ret = gluster_lock (fd, F_WRLCK, false);
         if (ret == -1) {
                 goto out;
         }

--- a/src/glfs-util.c
+++ b/src/glfs-util.c
@@ -315,7 +315,7 @@ out:
 
 // type is either F_RDLCK or F_WRLCK.
 int
-gluster_lock (glfs_fd_t *fd, short type) {
+gluster_lock (glfs_fd_t *fd, short type, bool block) {
     struct flock flck = {
         .l_type = type,
         .l_whence = SEEK_SET,
@@ -323,7 +323,7 @@ gluster_lock (glfs_fd_t *fd, short type) {
         .l_len = 0,  // lock entire file
     };
 
-    return glfs_posix_lock (fd, F_SETLK, &flck);
+    return glfs_posix_lock (fd, block ? F_SETLKW : F_SETLK, &flck);
 }
 
 int

--- a/src/glfs-util.h
+++ b/src/glfs-util.h
@@ -9,6 +9,7 @@
 
 #include <glusterfs/api/glfs.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 struct gluster_url {
         char *host;
@@ -53,7 +54,7 @@ int
 gluster_create_path (glfs_t *fs, char *path, mode_t omode);
 
 int
-gluster_lock (glfs_fd_t *fd, short type);
+gluster_lock (glfs_fd_t *fd, short type, bool block);
 
 int
 gluster_write (int src, glfs_fd_t *fd);

--- a/tests/flock.t
+++ b/tests/flock.t
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+
+GLUSTER_SHELL_CMD="gfcli glfs://$HOST/$GLUSTER_VOLUME"
+USAGE="Usage: flock [OPTION]... URL"
+GLUSTER_PROMPT="gfcli ($HOST/$GLUSTER_VOLUME)>"
+
+setup() {
+        TEST_LOCK_FILE=$(mktemp --tmpdir="$GLUSTER_MOUNT_DIR/$ROOT_DIR")
+        TEST_LOCK_FILE=$(basename "$TEST_LOCK_FILE")
+}
+
+teardown() {
+        rm -rf "$GLUSTER_MOUNT_DIR/$ROOT_DIR/$TEST_LOCK_FILE"
+}
+
+@test "Check without options" {
+        run bash -c "echo 'flock' | $GLUSTER_SHELL_CMD"
+
+        [[ "$output" =~ "$USAGE" ]]
+}
+
+@test "Check -h option" {
+        run bash -c "echo 'flock -h' | $GLUSTER_SHELL_CMD"
+
+        [[ "$output" =~ "$USAGE" ]]
+}
+
+@test "Check --help option" {
+        run bash -c "echo 'flock --help' | $GLUSTER_SHELL_CMD"
+
+        [[ "$output" =~ "$USAGE" ]]
+}
+
+@test "Try flock on a file without any options" {
+        run bash -c "echo \"flock $ROOT_DIR/$TEST_LOCK_FILE\" | $GLUSTER_SHELL_CMD"
+
+        echo "$GLUSTER_MOUNT_DIR, $TEST_LOCK_FILE"  > /tmp/file
+        [ "$output" == "$GLUSTER_PROMPT $GLUSTER_PROMPT " ]
+}
+
+@test "Try normal flock on a file with -s option" {
+        run bash -c "echo \"flock -s $ROOT_DIR/$TEST_LOCK_FILE\" | $GLUSTER_SHELL_CMD"
+
+        [ "$output" == "$GLUSTER_PROMPT $GLUSTER_PROMPT " ]
+}
+
+@test "Try flock on a file with --shared long option" {
+        run bash -c "echo \"flock --shared $ROOT_DIR/$TEST_LOCK_FILE\" | $GLUSTER_SHELL_CMD"
+
+        [ "$output" == "$GLUSTER_PROMPT $GLUSTER_PROMPT " ]
+}
+
+@test "Try conflicting write lock on a file with -e and -n options" {
+
+        run bash -c "exec 3>$GLUSTER_MOUNT_DIR/$ROOT_DIR/$TEST_LOCK_FILE; flock -s 3; echo \"flock -n -e $ROOT_DIR/$TEST_LOCK_FILE\" | $GLUSTER_SHELL_CMD; exec 3>&-"
+
+        [[ "$output" =~ "Resource temporarily unavailable" ]]
+}
+
+@test "Try acquiring shared lock on a file with read lock already being held" {
+        run bash -c "exec 3>$GLUSTER_MOUNT_DIR/$ROOT_DIR/$TEST_LOCK_FILE; flock -s 3; echo \"flock -n -s $ROOT_DIR/$TEST_LOCK_FILE\" | $GLUSTER_SHELL_CMD; exec 3>&-"
+
+        [ "$output" == "$GLUSTER_PROMPT $GLUSTER_PROMPT " ]
+}
+
+@test "Check --unlock option" {
+        run bash -c "echo \"flock --unlock $ROOT_DIR/$TEST_LOCK_FILE\" | $GLUSTER_SHELL_CMD;"
+
+        [ "$output" == "$GLUSTER_PROMPT $GLUSTER_PROMPT " ]
+
+}


### PR DESCRIPTION
This patch adds flock support for glusterfs-coreutils. Unlike other implemented core utils like cp, rm etc. flock will not be available as a stand-alone command. Because locks are always associated with file descriptors. So in order to keep those locks alive we need active fds. Standalone commands like gfrm, gfls etc. immediately closes the connection after completing their corresponding jobs which results in fd clean up and in turn to release locks for that fd. A small bats test for basic flock functionality testing is also available with this patch.

Signed-off-by: Anoop C S anoopcs@redhat.com
