### PR TITLE
Create links to gfcli under $(bindir)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,14 +5,13 @@ SUBDIRS = lib src man
 EXTRA_DIST = m4/gnulib-cache.m4
 
 install-exec-local:
-	$(LN_S) -f $(DESTDIR)$(bindir)/gfcli gfcat
-	$(LN_S) -f $(DESTDIR)$(bindir)/gfcli gfcp
-	$(LN_S) -f $(DESTDIR)$(bindir)/gfcli gfls
-	$(LN_S) -f $(DESTDIR)$(bindir)/gfcli gfmkdir
-	$(LN_S) -f $(DESTDIR)$(bindir)/gfcli gfmv
-	$(LN_S) -f $(DESTDIR)$(bindir)/gfcli gfrm
-	$(LN_S) -f $(DESTDIR)$(bindir)/gfcli gfstat
-	$(LN_S) -f $(DESTDIR)$(bindir)/gfcli gftail
+	$(LN_S) -f gfcli $(DESTDIR)$(bindir)/gfcat
+	$(LN_S) -f gfcli $(DESTDIR)$(bindir)/gfcp
+	$(LN_S) -f gfcli $(DESTDIR)$(bindir)/gfls
+	$(LN_S) -f gfcli $(DESTDIR)$(bindir)/gfmkdir
+	$(LN_S) -f gfcli $(DESTDIR)$(bindir)/gfrm
+	$(LN_S) -f gfcli $(DESTDIR)$(bindir)/gfstat
+	$(LN_S) -f gfcli $(DESTDIR)$(bindir)/gftail
 
 rpms:	prep
 	QA_RPATHS=17 rpmbuild --define '_topdir $(abs_top_builddir)/build/rpmbuild' \

--- a/glusterfs-coreutils.spec.in
+++ b/glusterfs-coreutils.spec.in
@@ -27,10 +27,6 @@ make
 %install
 make DESTDIR=${RPM_BUILD_ROOT} install
 
-for i in gfcat gfcp gfmkdir gfls gfrm gfstat gftail; do
-        ln -fs %{_bindir}/gfcli ${RPM_BUILD_ROOT}%{_bindir}/$i
-done
-
 %clean
 rm -rf ${RPM_BUILD_ROOT}
 


### PR DESCRIPTION
As of now 'make install' creates links to gfcli binary as gfcat, gfstat, gftail, etc directly under source. Instead for general usability of those commands it is good to have those links being created under the same directory where gfcli resides after 'make install'.

Signed-off-by: Anoop C S anoopcs@redhat.com
