### PR TITLE
Fix error checking for glfs_creat

### DIFF
--- a/src/glfs-touch.c
+++ b/src/glfs-touch.c
@@ -226,10 +226,12 @@ touch_with_fs (glfs_t *fs)
 {
         int ret;
         mode_t mode = get_default_dir_mode_perm ();
+        glfs_fd_t *fd;
 
-        ret = glfs_creat(fs, state->gluster_url->path, 0, mode);
 
-        if (ret == -1) {
+        fd = glfs_creat(fs, state->gluster_url->path, 0, mode);
+
+        if (fd == NULL || glfs_close (fd) == -1) {
                 error (0, errno, "cannot create file `%s'", state->url);
                 goto out;
         }


### PR DESCRIPTION
This avoids an int-conversion error and build failures with newer compilers.

Please note that I have not tested this (although the compiler error is gone). Found as part of:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
