### PR TITLE
build: address compile issue on Fedora 42

### DIFF
--- a/src/glfs-clear.c
+++ b/src/glfs-clear.c
@@ -78,7 +78,7 @@ usage ()
 }
 
 int
-do_clear()
+do_clear(struct cli_context *ctx)
 {
         int ret = 0;
         printf("\033[2J\033[1;1H");

--- a/src/glfs-clear.h
+++ b/src/glfs-clear.h
@@ -19,9 +19,10 @@
 #ifndef GLFS_CLEAR_H
 #define GLFS_CLEAR_H
 
+#include "glfs-cli.h"
 #include "glfs-clear.h"
 
 int
-do_clear();
+do_clear(struct cli_context *ctx);
 
 #endif

--- a/src/glfs-cli.c
+++ b/src/glfs-cli.c
@@ -64,7 +64,7 @@ struct cmd {
 };
 
 static int
-shell_usage ()
+shell_usage (struct cli_context *ctx)
 {
         printf ("The following commands are supported:\n"
                 "* cat\n"


### PR DESCRIPTION
The functions `shell_usage()` and `do_clear()` are missing a parameter:

```
glfs-cli.c:96:38: error: initialization of ‘int (*)(struct cli_context *)’ from incompatible pointer type ‘int (*)(void)’ [-Wincompatible-pointer-types]
   96 |         { .name = "help", .execute = shell_usage },
      |                                      ^~~~~~~~~~~
glfs-cli.c:96:38: note: (near initialization for ‘cmds[4].execute’)
glfs-cli.c:67:1: note: ‘shell_usage’ declared here
   67 | shell_usage ()
      | ^~~~~~~~~~~
```

Adding the (unused) `struct cli_context *` parameters to the functions makes the compiler happy again.

Fixes: https://bugzilla.redhat.com/2340236